### PR TITLE
AUTH-428: fix NPE under testCreateDeprecatedFeaturesDisabled

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/ProfileAssume.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/ProfileAssume.java
@@ -77,6 +77,7 @@ public class ProfileAssume {
     }
 
     private static boolean isFeatureEnabled(Profile.Feature feature) {
+        updateProfile();
         return !disabledFeatures.contains(feature.name());
     }
 }


### PR DESCRIPTION
AUTH-428: fix NPE under testCreateDeprecatedFeaturesDisabled