### PR TITLE
AUTH-432: Updated travis to build and deploy zip distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
     - MAVEN_SKIP_RC=true
     - MAVEN_OPTS="-Xms512m -Xmx1536m"
+    - THEME_VERSION=0.1
   matrix:
     - TESTS=unit
     - TESTS=server-group1
@@ -46,5 +47,20 @@ script:
 
 after_success:
   - .travis/docker-hub-master-trigger.sh
+
+before_deploy:
+  - mvn -Pdistribution -pl distribution/server-dist -am -Dmaven.test.skip clean install
+  - export KEYCLOAK_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+  - echo "Prepare deployment of keycloak-$KEYCLOAK_VERSION"
+  - ./add-alfresco-theme.sh
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  file: "distribution/server-dist/target/keycloak-$KEYCLOAK_VERSION.zip"
+  skip_cleanup: true
+  edge: true
+  on:
+    tags: true
 
 sudo: false

--- a/add-alfresco-theme.sh
+++ b/add-alfresco-theme.sh
@@ -14,12 +14,12 @@ print_usage() {
     The required environment variables are not set:
     - THEME_VERSION
     OR
-    - GIT_REPO
-    - GIT_BRANCH ('master' will be used if not set)
+    - THEME_GIT_REPO
+    - THEME_GIT_BRANCH ('master' will be used if not set)
 
     Example-1, adding alfresco-theme from a branch:
-        export GIT_REPO=alfresco-keycloak-theme
-        export GIT_BRANCH=test-branch
+        export THEME_GIT_REPO=alfresco-keycloak-theme
+        export THEME_GIT_BRANCH=test-branch
         sh add-alfresco-theme.sh
 
     Example-2, adding alfresco-theme from a released version:
@@ -29,7 +29,7 @@ EOF
     exit 1
 }
 
-if [ -z "$THEME_VERSION" ] && [ -z "$GIT_REPO" ]; then
+if [ -z "$THEME_VERSION" ] && [ -z "$THEME_GIT_REPO" ]; then
     print_usage
 fi
 
@@ -49,14 +49,14 @@ if [ ! -f "$KEYCLOAK_DIST" ]; then
 fi
 
 cd $TMP
-if [ -n "$GIT_REPO" ]; then
-    if [ -z "$GIT_BRANCH" ]; then
-        GIT_BRANCH='master'
+if [ -n "$THEME_GIT_REPO" ]; then
+    if [ -z "$THEME_GIT_BRANCH" ]; then
+        THEME_GIT_BRANCH='master'
     fi
 
     # Clone repository
-    log_info "Clone branch '$GIT_BRANCH' from repo: $GIT_REPO"
-    git clone --depth 1 https://github.com/Alfresco/$GIT_REPO.git -b $GIT_BRANCH alfresco-keycloak-theme
+    log_info "Clone branch '$THEME_GIT_BRANCH' from repo: $THEME_GIT_REPO"
+    git clone --depth 1 https://github.com/Alfresco/$THEME_GIT_REPO.git -b $THEME_GIT_BRANCH alfresco-keycloak-theme
 
     mkdir alfresco
     log_info "Copy Alfresco theme..."

--- a/add-alfresco-theme.sh
+++ b/add-alfresco-theme.sh
@@ -35,10 +35,12 @@ fi
 
 WORK_DIR="$PWD"
 TMP=$(mktemp -d)
-# Get keycloak version
-log_info "Getting keycloak version..."
-VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-log_info "Found keycloak version: $VERSION"
+VERSION="$KEYCLOAK_VERSION"
+if [ -z "$VERSION" ]; then
+    log_info "KEYCLOAK_VERSION environment variable is not set. Get the version from the project pom.xml"
+    VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+fi
+log_info "Using keycloak version: $VERSION"
 
 KEYCLOAK_DIR="$WORK_DIR/distribution/server-dist/target"
 KEYCLOAK_DIST="$KEYCLOAK_DIR/keycloak-$VERSION.zip"

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+TAG=$1
+
+if [ -z "$TAG" ]; then
+    echo "Tag argument is required."
+    echo "Example:"
+    echo "        sh tag.sh 7.0.1-patch"
+    exit 1
+fi
+
+CURRENT_BRANCH=$(git branch | grep '*' | cut -d' ' -f 2)
+
+echo "Do you wish to tag and push the current branch '$CURRENT_BRANCH' as '$TAG' ?"
+select yn in "Yes" "No"; do
+    case $yn in
+    Yes)
+        git tag "$TAG"
+        git push origin "$TAG"
+        break
+        ;;
+    No)
+        exit
+        ;;
+    esac
+done


### PR DESCRIPTION
Updated travis file to build and deploy (as a GitHub release) keycloak zip distribution when we tag a branch.


